### PR TITLE
 [bug 1137133] Use language names instead of codes

### DIFF
--- a/app/js/profile_controller.js
+++ b/app/js/profile_controller.js
@@ -4,7 +4,7 @@
 
 (function(exports) {
 
-  var LOCALES = ['en-US', 'fr', 'de'];
+  var LOCALES = ['en-US', 'fr', 'de', 'es', 'it', 'pt-BR', 'ro', 'tr'];
   var HANDSETS = [
     'All',
     'Alcatel',

--- a/app/js/profile_controller.js
+++ b/app/js/profile_controller.js
@@ -4,7 +4,16 @@
 
 (function(exports) {
 
-  var LOCALES = ['en-US', 'fr', 'de', 'es', 'it', 'pt-BR', 'ro', 'tr'];
+  var LOCALES = [
+    ['de', 'Deutsch'],
+    ['en-US', 'English'],
+    ['fr', 'Français'],
+    ['es', 'Español'],
+    ['it', 'Italiano'],
+    ['pt-BR', 'Português (do Brasil)'],
+    ['ro', 'română'],
+    ['tr', 'Türkçe']
+  ];
   var HANDSETS = [
     'All',
     'Alcatel',

--- a/app/js/templates.js
+++ b/app/js/templates.js
@@ -181,12 +181,14 @@ frame.set("loop.first", t_1 === 0);
 frame.set("loop.last", t_1 === t_2 - 1);
 frame.set("loop.length", t_2);
 output += "\n                <option ";
-if(t_4 == runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "user")),"locale", env.autoesc)) {
+if(runtime.memberLookup((t_4),0, env.autoesc) == runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "user")),"locale", env.autoesc)) {
 output += "selected=\"selected\"";
 ;
 }
-output += ">";
-output += runtime.suppressValue(t_4, env.autoesc);
+output += " value=\"";
+output += runtime.suppressValue(runtime.memberLookup((t_4),0, env.autoesc), env.autoesc);
+output += "\">";
+output += runtime.suppressValue(runtime.memberLookup((t_4),1, env.autoesc), env.autoesc);
 output += "</option>\n              ";
 ;
 }

--- a/app/views/my-profile.html
+++ b/app/views/my-profile.html
@@ -33,7 +33,7 @@
             <div class="button" data-icon="expand">
               <select id="locale">
               {% for locale in locales %}
-                <option {% if locale == user.locale %}selected="selected"{% endif %}>{{ locale }}</option>
+                <option {% if locale[0] == user.locale %}selected="selected"{% endif %} value="{{ locale[0] }}">{{ locale[1] }}</option>
               {% endfor %}
               </select>
             </div>


### PR DESCRIPTION
Includes the commit from #168.

This pull is for bfd7b0f onwards.

r?