### PR TITLE
[Bug 1195806] Pin Nunjucks to v1.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "jshint": "^2.6.0",
     "lodash": "^3.7.0",
     "marionette-client": "^1.7.3",
-    "moment": "^2.10.3"
+    "moment": "^2.10.3",
+    "nunjucks": "1.2.x"
   },
   "engine": "node >= 0.10.x",
   "volo": {


### PR DESCRIPTION
Something in 1.3 causes us to break. I bet it is [this commit](https://github.com/mozilla/nunjucks/commit/9a77099ce2c8a861bcdd467a821892b1707d93f2).

r?