### PR TITLE
[Bug 1202232] Remove `defer` from all script tags.

### DIFF
--- a/app/authentication.html
+++ b/app/authentication.html
@@ -22,8 +22,8 @@
     <!-- localization -->
     <link rel="prefetch" type="application/l10n" href="data/locales.ini" />
     <link rel="prefetch" type="application/l10n" href="data/date/date.ini" />
-    <script src="js/libs/l10n.js" defer></script>
-    <script src="js/libs/l10n_date.js" defer></script>
+    <script src="js/libs/l10n.js"></script>
+    <script src="js/libs/l10n_date.js"></script>
   </head>
   <body class="skin-organic">
   <section role="region" class="vbox fit" data-template="main/authentication.html"></section>
@@ -32,20 +32,20 @@
   <script src="js/settings.js"></script>
   <script src="js/libs/lodash.custom.min.js"></script>
   <script src="js/libs/async_storage.js"></script>
-  <script src="js/user.js" defer></script>
+  <script src="js/user.js"></script>
 
-  <script src="js/libs/nunjucks-slim.js" defer></script>
-  <script src="js/templates.js" defer></script>
-  <script src="js/nunjucks_env.js" defer></script>
+  <script src="js/libs/nunjucks-slim.js"></script>
+  <script src="js/templates.js"></script>
+  <script src="js/nunjucks_env.js"></script>
 
-  <script src="js/l10n.js" defer></script>
-  <script src="js/libs/font_size_utils.js" defer></script>
-  <script src="js/loader.js" defer></script>
+  <script src="js/l10n.js"></script>
+  <script src="js/libs/font_size_utils.js"></script>
+  <script src="js/loader.js"></script>
 
-  <script src="js/utils.js" defer></script>
-  <script src="js/sumo_db.js" defer></script>
-  <script src="js/error_controller.js" defer></script>
-  <script src="js/loading_indicator.js" defer></script>
-  <script src="js/authentication_controller.js" defer></script>
+  <script src="js/utils.js"></script>
+  <script src="js/sumo_db.js"></script>
+  <script src="js/error_controller.js"></script>
+  <script src="js/loading_indicator.js"></script>
+  <script src="js/authentication_controller.js"></script>
   </body>
 </html>

--- a/app/email_confirmation.html
+++ b/app/email_confirmation.html
@@ -20,20 +20,20 @@
   <!-- localization -->
   <link rel="prefetch" type="application/l10n" href="data/locales.ini" />
   <link rel="prefetch" type="application/l10n" href="data/date/date.ini" />
-  <script src="js/libs/l10n.js" defer></script>
-  <script src="js/libs/l10n_date.js" defer></script>
+  <script src="js/libs/l10n.js"></script>
+  <script src="js/libs/l10n_date.js"></script>
 </head>
 <body class="skin-organic">
   <div class="flex-container" data-template="main/email_confirmation.html"></div>
 
   <script src="js/load_translations.js"></script>
-  <script src="js/libs/i18n.js" defer></script>
-  <script src="js/libs/font_size_utils.js" defer></script>
-  <script src="js/utils.js" defer></script>
-  <script src="js/libs/nunjucks-slim.js" defer></script>
-  <script src="js/templates.js" defer></script>
-  <script src="js/nunjucks_env.js" defer></script>
-  <script src="js/loader.js" defer></script>
+  <script src="js/libs/i18n.js"></script>
+  <script src="js/libs/font_size_utils.js"></script>
+  <script src="js/utils.js"></script>
+  <script src="js/libs/nunjucks-slim.js"></script>
+  <script src="js/templates.js"></script>
+  <script src="js/nunjucks_env.js"></script>
+  <script src="js/loader.js"></script>
 
   <script src="js/libs/lodash.custom.min.js"></script>
   <script src="js/libs/async_storage.js"></script>

--- a/app/helper_profile.html
+++ b/app/helper_profile.html
@@ -20,8 +20,8 @@
   <!-- localization -->
   <link rel="prefetch" type="application/l10n" href="data/locales.ini" />
   <link rel="prefetch" type="application/l10n" href="data/date/date.ini" />
-  <script src="js/libs/l10n.js" defer></script>
-  <script src="js/libs/l10n_date.js" defer></script>
+  <script src="js/libs/l10n.js"></script>
+  <script src="js/libs/l10n_date.js"></script>
 </head>
 <body class="skin-organic">
   <section role="region" class="vbox fit" data-template="main/helper_profile.html"></section>
@@ -29,19 +29,19 @@
   <script src="js/load_translations.js"></script>
   <script src="js/settings.js"></script>
   <script src="js/libs/async_storage.js"></script>
-  <script src="js/libs/lodash.custom.min.js" defer></script>
-  <script src="js/libs/nunjucks-slim.js" defer></script>
-  <script src="js/templates.js" defer></script>
-  <script src="js/nunjucks_env.js" defer></script>
-  <script src="js/l10n.js" defer></script>
-  <script src="js/libs/font_size_utils.js" defer></script>
-  <script src="js/loader.js" defer></script>
+  <script src="js/libs/lodash.custom.min.js"></script>
+  <script src="js/libs/nunjucks-slim.js"></script>
+  <script src="js/templates.js"></script>
+  <script src="js/nunjucks_env.js"></script>
+  <script src="js/l10n.js"></script>
+  <script src="js/libs/font_size_utils.js"></script>
+  <script src="js/loader.js"></script>
 
-  <script src="js/utils.js" defer></script>
-  <script src="js/sumo_db.js" defer></script>
-  <script src="js/error_controller.js" defer></script>
-  <script src="js/loading_indicator.js" defer></script>
-  <script src="js/user.js" defer></script>
-  <script src="js/helper_profile_controller.js" defer></script>
+  <script src="js/utils.js"></script>
+  <script src="js/sumo_db.js"></script>
+  <script src="js/error_controller.js"></script>
+  <script src="js/loading_indicator.js"></script>
+  <script src="js/user.js"></script>
+  <script src="js/helper_profile_controller.js"></script>
 </body>
 </html>

--- a/app/home.html
+++ b/app/home.html
@@ -28,27 +28,27 @@
     <section role="region" class="vbox fit" data-template="main/home.html"></section>
 
     <script src="js/load_translations.js"></script>
-    <script src="js/libs/l10n.js" defer></script>
-    <script src="js/libs/l10n_date.js" defer></script>
+    <script src="js/libs/l10n.js"></script>
+    <script src="js/libs/l10n_date.js"></script>
     <script src="js/settings.js"></script>
     <script src="js/libs/lodash.custom.min.js"></script>
     <script src="js/libs/async_storage.js"></script>
-    <script src="js/user.js" defer></script>
+    <script src="js/user.js"></script>
 
-    <script src="js/libs/nunjucks-slim.js" defer></script>
-    <script src="js/templates.js" defer></script>
-    <script src="js/nunjucks_env.js" defer></script>
+    <script src="js/libs/nunjucks-slim.js"></script>
+    <script src="js/templates.js"></script>
+    <script src="js/nunjucks_env.js"></script>
 
 
-    <script src="js/l10n.js" defer></script>
-    <script src="js/libs/font_size_utils.js" defer></script>
-    <script src="js/loader.js" defer></script>
+    <script src="js/l10n.js"></script>
+    <script src="js/libs/font_size_utils.js"></script>
+    <script src="js/loader.js"></script>
 
-    <script src="js/utils.js" defer></script>
-    <script src="js/sumo_db.js" defer></script>
-    <script src="js/error_controller.js" defer></script>
-    <script src="js/loading_indicator.js" defer></script>
-    <script src="js/home_controller.js" defer></script>
-    <script src="js/questions_controller.js" defer></script>
+    <script src="js/utils.js"></script>
+    <script src="js/sumo_db.js"></script>
+    <script src="js/error_controller.js"></script>
+    <script src="js/loading_indicator.js"></script>
+    <script src="js/home_controller.js"></script>
+    <script src="js/questions_controller.js"></script>
   </body>
 </html>

--- a/app/kb.html
+++ b/app/kb.html
@@ -18,17 +18,17 @@
     <!-- localization -->
     <link rel="prefetch" type="application/l10n" href="data/locales.ini" />
     <link rel="prefetch" type="application/l10n" href="data/date/date.ini" />
-    <script src="js/libs/l10n.js" defer></script>
+    <script src="js/libs/l10n.js"></script>
   </head>
   <body class="skin-organic">
     <section role="region" class="vbox fit" data-template="main/kb.html"></section>
 
     <script src="js/load_translations.js"></script>
-    <script src="js/libs/nunjucks-slim.js" defer></script>
-    <script src="js/templates.js" defer></script>
-    <script src="js/nunjucks_env.js" defer></script>
-    <script src="js/l10n.js" defer></script>
-    <script src="js/libs/font_size_utils.js" defer></script>
+    <script src="js/libs/nunjucks-slim.js"></script>
+    <script src="js/templates.js"></script>
+    <script src="js/nunjucks_env.js"></script>
+    <script src="js/l10n.js"></script>
+    <script src="js/libs/font_size_utils.js"></script>
     <script src="js/settings.js"></script>
     <script src="js/loader.js"></script>
     <script src="js/utils.js"></script>

--- a/app/old_versions.html
+++ b/app/old_versions.html
@@ -19,16 +19,16 @@
   <!-- localization -->
   <link rel="prefetch" type="application/l10n" href="data/locales.ini" />
   <link rel="prefetch" type="application/l10n" href="data/date/date.ini" />
-  <script src="js/libs/l10n.js" defer></script>
-  <script src="js/libs/l10n_date.js" defer></script>
+  <script src="js/libs/l10n.js"></script>
+  <script src="js/libs/l10n_date.js"></script>
 </head>
 <body class="skin-organic">
   <form id="unsupported-device" role="dialog" data-type="confirm" data-template="main/old_versions.html"></form>
 
   <script src="js/load_translations.js"></script>
-  <script src="js/libs/nunjucks-slim.js" defer></script>
-  <script src="js/templates.js" defer></script>
-  <script src="js/nunjucks_env.js" defer></script>
+  <script src="js/libs/nunjucks-slim.js"></script>
+  <script src="js/templates.js"></script>
+  <script src="js/nunjucks_env.js"></script>
   <script src="js/loader.js"></script>
   <script src="js/old_versions_controller.js"></script>
 </body>

--- a/app/password_reset.html
+++ b/app/password_reset.html
@@ -22,8 +22,8 @@
   <!-- localization -->
   <link rel="prefetch" type="application/l10n" href="data/locales.ini" />
   <link rel="prefetch" type="application/l10n" href="data/date/date.ini" />
-  <script src="js/libs/l10n.js" defer></script>
-  <script src="js/libs/l10n_date.js" defer></script>
+  <script src="js/libs/l10n.js"></script>
+  <script src="js/libs/l10n_date.js"></script>
 </head>
 <body class="skin-organic">
   <section role="region" class="vbox fit" data-template="main/password_reset.html"></section>
@@ -32,19 +32,19 @@
   <script src="js/settings.js"></script>
   <script src="js/libs/lodash.custom.min.js"></script>
   <script src="js/libs/async_storage.js"></script>
-  <script src="js/user.js" defer></script>
+  <script src="js/user.js"></script>
 
-  <script src="js/libs/nunjucks-slim.js" defer></script>
-  <script src="js/templates.js" defer></script>
-  <script src="js/nunjucks_env.js" defer></script>
-  <script src="js/l10n.js" defer></script>
-  <script src="js/libs/font_size_utils.js" defer></script>
-  <script src="js/loader.js" defer></script>
+  <script src="js/libs/nunjucks-slim.js"></script>
+  <script src="js/templates.js"></script>
+  <script src="js/nunjucks_env.js"></script>
+  <script src="js/l10n.js"></script>
+  <script src="js/libs/font_size_utils.js"></script>
+  <script src="js/loader.js"></script>
 
-  <script src="js/utils.js" defer></script>
-  <script src="js/sumo_db.js" defer></script>
-  <script src="js/error_controller.js" defer></script>
-  <script src="js/loading_indicator.js" defer></script>
-  <script src="js/password_reset_controller.js" defer></script>
+  <script src="js/utils.js"></script>
+  <script src="js/sumo_db.js"></script>
+  <script src="js/error_controller.js"></script>
+  <script src="js/loading_indicator.js"></script>
+  <script src="js/password_reset_controller.js"></script>
 </body>
 </html>

--- a/app/profile.html
+++ b/app/profile.html
@@ -25,8 +25,8 @@
     <!-- localization -->
     <link rel="prefetch" type="application/l10n" href="data/locales.ini" />
     <link rel="prefetch" type="application/l10n" href="data/date/date.ini" />
-    <script src="js/libs/l10n.js" defer></script>
-    <script src="js/libs/l10n_date.js" defer></script>
+    <script src="js/libs/l10n.js"></script>
+    <script src="js/libs/l10n_date.js"></script>
   </head>
   <body class="skin-organic">
     <section role="region" class="vbox fit" data-template="main/profile.html"></section>
@@ -35,18 +35,18 @@
     <script src="js/settings.js"></script>
     <script src="js/libs/lodash.custom.min.js"></script>
     <script src="js/libs/async_storage.js"></script>
-    <script src="js/libs/nunjucks-slim.js" defer></script>
-    <script src="js/templates.js" defer></script>
-    <script src="js/nunjucks_env.js" defer></script>
-    <script src="js/l10n.js" defer></script>
-    <script src="js/libs/font_size_utils.js" defer></script>
-    <script src="js/loader.js" defer></script>
+    <script src="js/libs/nunjucks-slim.js"></script>
+    <script src="js/templates.js"></script>
+    <script src="js/nunjucks_env.js"></script>
+    <script src="js/l10n.js"></script>
+    <script src="js/libs/font_size_utils.js"></script>
+    <script src="js/loader.js"></script>
 
-    <script src="js/utils.js" defer></script>
-    <script src="js/sumo_db.js" defer></script>
-    <script src="js/error_controller.js" defer></script>
-    <script src="js/loading_indicator.js" defer></script>
-    <script src="js/user.js" defer></script>
-    <script src="js/profile_controller.js" defer></script>
+    <script src="js/utils.js"></script>
+    <script src="js/sumo_db.js"></script>
+    <script src="js/error_controller.js"></script>
+    <script src="js/loading_indicator.js"></script>
+    <script src="js/user.js"></script>
+    <script src="js/profile_controller.js"></script>
   </body>
 </html>

--- a/app/question.html
+++ b/app/question.html
@@ -23,29 +23,29 @@
     <!-- localization -->
     <link rel="prefetch" type="application/l10n" href="data/locales.ini" />
     <link rel="prefetch" type="application/l10n" href="data/date/date.ini" />
-    <script src="js/libs/l10n.js" defer></script>
-    <script src="js/libs/l10n_date.js" defer></script>
+    <script src="js/libs/l10n.js"></script>
+    <script src="js/libs/l10n_date.js"></script>
   </head>
   <body class="skin-organic">
     <div class="flex-container" data-template="main/question.html"></div>
 
     <script src="js/load_translations.js"></script>
     <script src="js/settings.js"></script>
-    <script src="js/libs/async_storage.js" defer></script>
-    <script src="js/libs/nunjucks-slim.js" defer></script>
-    <script src="js/libs/lodash.custom.min.js" defer></script>
-    <script src="js/templates.js" defer></script>
-    <script src="js/nunjucks_env.js" defer></script>
-    <script src="js/l10n.js" defer></script>
-    <script src="js/libs/font_size_utils.js" defer></script>
-    <script src="js/loader.js" defer></script>
+    <script src="js/libs/async_storage.js"></script>
+    <script src="js/libs/nunjucks-slim.js"></script>
+    <script src="js/libs/lodash.custom.min.js"></script>
+    <script src="js/templates.js"></script>
+    <script src="js/nunjucks_env.js"></script>
+    <script src="js/l10n.js"></script>
+    <script src="js/libs/font_size_utils.js"></script>
+    <script src="js/loader.js"></script>
 
-    <script src="js/mobile_operator.js" defer></script>
-    <script src="js/utils.js" defer></script>
-    <script src="js/user.js" defer></script>
-    <script src="js/sumo_db.js" defer></script>
-    <script src="js/error_controller.js" defer></script>
-    <script src="js/loading_indicator.js" defer></script>
-    <script src="js/question_controller.js" defer></script>
+    <script src="js/mobile_operator.js"></script>
+    <script src="js/utils.js"></script>
+    <script src="js/user.js"></script>
+    <script src="js/sumo_db.js"></script>
+    <script src="js/error_controller.js"></script>
+    <script src="js/loading_indicator.js"></script>
+    <script src="js/question_controller.js"></script>
   </body>
 </html>

--- a/app/question_list_helpee.html
+++ b/app/question_list_helpee.html
@@ -20,8 +20,8 @@
     <!-- localization -->
     <link rel="prefetch" type="application/l10n" href="data/locales.ini" />
     <link rel="prefetch" type="application/l10n" href="data/date/date.ini" />
-    <script src="js/libs/l10n.js" defer></script>
-    <script src="js/libs/l10n_date.js" defer></script>
+    <script src="js/libs/l10n.js"></script>
+    <script src="js/libs/l10n_date.js"></script>
   </head>
   <body class="skin-organic">
     <section role="region" class="vbox fit" data-template="main/question_list_helpee.html"></section>
@@ -29,19 +29,19 @@
     <script src="js/load_translations.js"></script>
     <script src="js/settings.js"></script>
     <script src="js/libs/lodash.custom.min.js"></script>
-    <script src="js/libs/async_storage.js" defer></script>
-    <script src="js/libs/nunjucks-slim.js" defer></script>
-    <script src="js/templates.js" defer></script>
-    <script src="js/nunjucks_env.js" defer></script>
-    <script src="js/l10n.js" defer></script>
-    <script src="js/libs/font_size_utils.js" defer></script>
-    <script src="js/loader.js" defer></script>
+    <script src="js/libs/async_storage.js"></script>
+    <script src="js/libs/nunjucks-slim.js"></script>
+    <script src="js/templates.js"></script>
+    <script src="js/nunjucks_env.js"></script>
+    <script src="js/l10n.js"></script>
+    <script src="js/libs/font_size_utils.js"></script>
+    <script src="js/loader.js"></script>
 
-    <script src="js/utils.js" defer></script>
-    <script src="js/user.js" defer></script>
-    <script src="js/sumo_db.js" defer></script>
-    <script src="js/error_controller.js" defer></script>
-    <script src="js/loading_indicator.js" defer></script>
-    <script src="js/questions_controller.js" defer></script>
+    <script src="js/utils.js"></script>
+    <script src="js/user.js"></script>
+    <script src="js/sumo_db.js"></script>
+    <script src="js/error_controller.js"></script>
+    <script src="js/loading_indicator.js"></script>
+    <script src="js/questions_controller.js"></script>
 </body>
 </html>

--- a/app/question_list_helper.html
+++ b/app/question_list_helper.html
@@ -24,8 +24,8 @@
     <!-- localization -->
     <link rel="prefetch" type="application/l10n" href="data/locales.ini" />
     <link rel="prefetch" type="application/l10n" href="data/date/date.ini" />
-    <script src="js/libs/l10n.js" defer></script>
-    <script src="js/libs/l10n_date.js" defer></script>
+    <script src="js/libs/l10n.js"></script>
+    <script src="js/libs/l10n_date.js"></script>
   </head>
   <body class="skin-organic">
     <section role="region" class="vbox fit" data-template="main/question_list_helper.html"></section>
@@ -33,19 +33,19 @@
     <script src="js/load_translations.js"></script>
     <script src="js/settings.js"></script>
     <script src="js/libs/lodash.custom.min.js"></script>
-    <script src="js/libs/async_storage.js" defer></script>
-    <script src="js/libs/nunjucks-slim.js" defer></script>
-    <script src="js/templates.js" defer></script>
-    <script src="js/nunjucks_env.js" defer></script>
-    <script src="js/l10n.js" defer></script>
-    <script src="js/libs/font_size_utils.js" defer></script>
-    <script src="js/loader.js" defer></script>
+    <script src="js/libs/async_storage.js"></script>
+    <script src="js/libs/nunjucks-slim.js"></script>
+    <script src="js/templates.js"></script>
+    <script src="js/nunjucks_env.js"></script>
+    <script src="js/l10n.js"></script>
+    <script src="js/libs/font_size_utils.js"></script>
+    <script src="js/loader.js"></script>
 
-    <script src="js/utils.js" defer></script>
-    <script src="js/user.js" defer></script>
-    <script src="js/sumo_db.js" defer></script>
-    <script src="js/error_controller.js" defer></script>
-    <script src="js/loading_indicator.js" defer></script>
-    <script src="js/questions_controller.js" defer></script>
+    <script src="js/utils.js"></script>
+    <script src="js/user.js"></script>
+    <script src="js/sumo_db.js"></script>
+    <script src="js/error_controller.js"></script>
+    <script src="js/loading_indicator.js"></script>
+    <script src="js/questions_controller.js"></script>
 </body>
 </html>

--- a/app/registration.html
+++ b/app/registration.html
@@ -22,8 +22,8 @@
   <!-- localization -->
   <link rel="prefetch" type="application/l10n" href="data/locales.ini" />
   <link rel="prefetch" type="application/l10n" href="data/date/date.ini" />
-  <script src="js/libs/l10n.js" defer></script>
-  <script src="js/libs/l10n_date.js" defer></script>
+  <script src="js/libs/l10n.js"></script>
+  <script src="js/libs/l10n_date.js"></script>
 </head>
 <body class="skin-organic">
   <section role="region" class="vbox fit" data-template="main/registration.html"></section>
@@ -32,19 +32,19 @@
   <script src="js/settings.js"></script>
   <script src="js/libs/async_storage.js"></script>
   <script src="js/libs/lodash.custom.min.js"></script>
-  <script src="js/user.js" defer></script>
+  <script src="js/user.js"></script>
 
-  <script src="js/libs/nunjucks-slim.js" defer></script>
-  <script src="js/templates.js" defer></script>
-  <script src="js/nunjucks_env.js" defer></script>
-  <script src="js/l10n.js" defer></script>
-  <script src="js/libs/font_size_utils.js" defer></script>
-  <script src="js/loader.js" defer></script>
+  <script src="js/libs/nunjucks-slim.js"></script>
+  <script src="js/templates.js"></script>
+  <script src="js/nunjucks_env.js"></script>
+  <script src="js/l10n.js"></script>
+  <script src="js/libs/font_size_utils.js"></script>
+  <script src="js/loader.js"></script>
 
-  <script src="js/utils.js" defer></script>
-  <script src="js/sumo_db.js" defer></script>
-  <script src="js/error_controller.js" defer></script>
-  <script src="js/loading_indicator.js" defer></script>
-  <script src="js/registration_controller.js" defer></script>
+  <script src="js/utils.js"></script>
+  <script src="js/sumo_db.js"></script>
+  <script src="js/error_controller.js"></script>
+  <script src="js/loading_indicator.js"></script>
+  <script src="js/registration_controller.js"></script>
 </body>
 </html>

--- a/app/unsupported_locale.html
+++ b/app/unsupported_locale.html
@@ -20,20 +20,20 @@
   <!-- localization -->
   <link rel="prefetch" type="application/l10n" href="data/locales.ini" />
   <link rel="prefetch" type="application/l10n" href="data/date/date.ini" />
-  <script src="js/libs/l10n.js" defer></script>
-  <script src="js/libs/l10n_date.js" defer></script>
+  <script src="js/libs/l10n.js"></script>
+  <script src="js/libs/l10n_date.js"></script>
 </head>
 <body class="skin-organic">
 <div class="flex-container" data-template="main/unsupported_locale.html"></div>
 
 <script src="js/load_translations.js"></script>
-<script src="js/i18n.js.js" defer></script>
-<script src="js/libs/nunjucks-slim.js" defer></script>
-<script src="js/templates.js" defer></script>
-<script src="js/nunjucks_env.js" defer></script>
-<script src="js/libs/font_size_utils.js" defer></script>
-<script src="js/utils.js" defer></script>
-<script src="js/loader.js" defer></script>
+<script src="js/i18n.js.js"></script>
+<script src="js/libs/nunjucks-slim.js"></script>
+<script src="js/templates.js"></script>
+<script src="js/nunjucks_env.js"></script>
+<script src="js/libs/font_size_utils.js"></script>
+<script src="js/utils.js"></script>
+<script src="js/loader.js"></script>
 
 <script src="js/libs/lodash.custom.min.js"></script>
 <script src="js/libs/async_storage.js"></script>


### PR DESCRIPTION
Bug 1202232 was, in particular, caused by `nunjucks_env.js` being loaded with `defer`, but `loader.js` not being loaded with `defer`.

Since the regex to remove defer everywhere was easier than the regex to add it to all the places it was missing, I did this.

r?