### PR TITLE
[Bug 1206864] Localize known API error messages.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -13,11 +13,11 @@
     <script src="js/load_translations.js"></script>
     <script src="js/libs/l10n.js"></script>
     <script src="js/settings.js"></script>
+    <script src="js/l10n.js"></script>
     <script src="js/utils.js"></script>
     <script src="js/libs/lodash.custom.min.js"></script>
     <script src="js/libs/async_storage.js"></script>
     <script src="js/user.js"></script>
-    <script src="js/l10n.js"></script>
     <script src="js/sumo_db.js"></script>
     <script src="js/notifications.js"></script>
     <script src="js/launch_checks.js"></script>

--- a/app/js/utils.js
+++ b/app/js/utils.js
@@ -92,6 +92,13 @@
       model: 'Open II' },
   ];
 
+  const LOCALIZED_ERRORS = {
+    'This field is required.': gettext('This field is required.'),
+    'Unable to login with provided credentials.': gettext('Unable to login with provided credentials.'),
+    'A user with that email address already exists.': gettext('A user with that email address already exists.'),
+    'A user with that username exists': gettext('A user with that username exists'),
+  };
+
   function useragent_to_device(useragent) {
     var device = DEVICES.find(function(device) {
       return useragent.toLowerCase().startsWith(device.useragent.toLowerCase());
@@ -227,8 +234,14 @@
       list.innerHTML = '';
       if (errors) {
         for (var i in errors) {
+          var localizedError;
+          if (errors[i] in LOCALIZED_ERRORS) {
+            localizedError = LOCALIZED_ERRORS[errors[i]];
+          } else {
+            localizedError = gettext('Unknown error: "{error}"', {error: errors[i]});
+          }
           var error = document.createElement('li');
-          error.appendChild(document.createTextNode(errors[i]));
+          error.appendChild(document.createTextNode(localizedError));
           list.appendChild(error);
         }
       }

--- a/app/js/utils.js
+++ b/app/js/utils.js
@@ -97,6 +97,10 @@
     'Unable to login with provided credentials.': gettext('Unable to login with provided credentials.'),
     'A user with that email address already exists.': gettext('A user with that email address already exists.'),
     'A user with that username exists': gettext('A user with that username exists'),
+    "Can't change this field.": gettext("Can't change this field."),
+    'Usernames may only be letters, numbers, "." and "-".': gettext('Usernames may only be letters, numbers, "." and "-".'),
+    'No matching user setting found.': gettext('No matching user setting found.'),
+    'Unable to generate username.': gettext('Unable to generate username.'),
   };
 
   function useragent_to_device(useragent) {


### PR DESCRIPTION
It's, well, not pretty. I think it works though. Almost makes me wish JS had macros.

I think this is all the errors we'll get. It is all that are mentioned in the bugs, and all that I could figure out how to trigger in places that called `refresh_error_list`. Though maybe there are some API error messages where `refresh_error_list` isn't called?

Did I miss anything? r?