### PR TITLE
[Bug 1213375] Add two more localized API errors.

### DIFF
--- a/app/js/utils.js
+++ b/app/js/utils.js
@@ -101,6 +101,8 @@
     'Usernames may only be letters, numbers, "." and "-".': gettext('Usernames may only be letters, numbers, "." and "-".'),
     'No matching user setting found.': gettext('No matching user setting found.'),
     'Unable to generate username.': gettext('Unable to generate username.'),
+    'User account is disabled': gettext('User account is disabled'),
+    'Enter a valid email address': gettext('Enter a valid email address'),
   };
 
   function useragent_to_device(useragent) {


### PR DESCRIPTION
This is assuming that the missing error messages from [1213375](https://bugzilla.mozilla.org/show_bug.cgi?id=1213375) are actually going through this error localization system. Waiting for Fredy to confirm.

Tiny r?